### PR TITLE
fix: base を rust:1.97.1-slim-trixie に更新して libmariadb のリグレッションを回避する

### DIFF
--- a/server/Dockerfile-database-migration
+++ b/server/Dockerfile-database-migration
@@ -1,5 +1,10 @@
-# syntax=docker/dockerfile:1.26
-FROM rust:1.97.1-slim-bookworm
+# syntax=docker/dockerfile:1
+# bookworm の libmariadb (1:10.11.18) には MariaDB 11.x サーバーに対して
+# 文字列カラムを空として読むリグレッションがあり、__diesel_schema_migrations を
+# 読めず適用済みマイグレーションを再実行してしまう (diesel-rs/diesel#5102)。
+# trixie の libmariadb (1:11.8.6) では解消していることを検証済み。
+# base を bookworm に戻さないこと
+FROM rust:1.97.1-slim-trixie
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y default-libmysqlclient-dev && \

--- a/server/Dockerfile-ingestor
+++ b/server/Dockerfile-ingestor
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.26
+# syntax=docker/dockerfile:1
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR /app
 


### PR DESCRIPTION
## 背景

#197 (`sha-8cf3333`) を適用しても ingestor CronJob の失敗が継続していた。init コンテナのログでは、版数が DB の記録 (`20230524025310`) と完全一致しているにもかかわらず初回マイグレーションを再実行して `Table 'break_count_full_snapshot_point' already exists` で失敗する。

## 真因

**bookworm の libmariadb `1:10.11.18-0+deb12u1`(動的リンク)が MariaDB 11.x サーバーに対して文字列カラムを空文字列として読むリグレッション**(diesel-rs/diesel#5102 と同一)。`__diesel_schema_migrations` の `version` が空として読まれるため、diesel が適用済みマイグレーションを検出できない。

- 旧イメージ (2023 年ビルド) は libmariadb `1:10.11.3-1` で影響なし → イメージ再ビルドで壊れた
- クラスタ内の新イメージで `diesel migration list` を実行すると `[ ]`(未適用扱い)になることを確認済み

## 検証

ローカルの MariaDB 11.8(本番は 11.8.8)に本番同等の `__diesel_schema_migrations` 行を投入し、diesel_cli 2.3.11 を動的リンクでビルドして比較:

| base | libmariadb | `diesel migration list` |
|---|---|---|
| bookworm | 1:10.11.18-0+deb12u1 | `[ ]` 誤判定(バグ再現) |
| **trixie** | **1:11.8.6-0+deb13u1** | **`[X]` 正しく認識** |

base イメージの変更のみで解決するため、`mysql-bundled`(ソースからの同梱ビルド)は採用しない。

## 補足

- ingestor 本体は diesel-async (mysql_async, 純 Rust 実装) で libmysqlclient をリンクしていないため影響なし(ランタイムは distroless + libz のみ)
- マージ後、seichi_infra 側のイメージ bump が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)