### PR TITLE
ci: アーカイブ済みの actions-rs 系 action を置き換える

### DIFF
--- a/.github/workflows/build-and-release-application.yaml
+++ b/.github/workflows/build-and-release-application.yaml
@@ -13,10 +13,15 @@ jobs:
         uses: actions/checkout@v7
 
       # reads toolchain info from /rust-toolchain.toml
-      # we are using a fork of actions-rs/toolchain for rust-toolchain.toml support
-      # (see https://github.com/actions-rs/toolchain/pull/209) for details.
+      # cargo のエラー/警告の GitHub UI 表示はこの action が登録する problem matcher が行う
       - name: Setup Rust toolchain
-        uses: oxidecomputer/actions-rs_toolchain@ad3f86084a8a5acf2c09cb691421b31cf8af7a36
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+          # キャッシュは後続の Swatinem/rust-cache で行う
+          cache: false
+          # デフォルトだと RUSTFLAGS=-D warnings が注入され warning がすべてエラー化してしまう
+          rustflags: ""
 
       # > selecting a toolchain either by action or manual `rustup` calls should happen
       # > before the plugin, as it uses the current rustc version as its cache key
@@ -28,31 +33,17 @@ jobs:
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
 
-      # GitHubのUIにエラー/警告を表示してくれるので actions-rs/cargo を利用している
-
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path server/Cargo.toml --all -- --check
+        run: cargo fmt --manifest-path server/Cargo.toml --all -- --check
 
       - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --manifest-path server/Cargo.toml
+        run: cargo build --manifest-path server/Cargo.toml
 
       - name: Cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path server/Cargo.toml
+        run: cargo clippy --manifest-path server/Cargo.toml
 
       - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path server/Cargo.toml --all-features
+        run: cargo test --manifest-path server/Cargo.toml --all-features
 
   build-image:
     strategy:


### PR DESCRIPTION
## 背景

CI が使っている `oxidecomputer/actions-rs_toolchain`(actions-rs/toolchain の fork)と `actions-rs/cargo` は、上流が 2020 年からアーカイブ済みで、GitHub が廃止を進めている古い Node ランタイムで動作しています。seichi-timed-stats-server では actionlint にも指摘されました(GiganticMinecraft/seichi-timed-stats-server#164 参照)。

## 変更内容

- `oxidecomputer/actions-rs_toolchain` fork → `actions-rust-lang/setup-rust-toolchain@v1`
  - fork を使っていた理由だった rust-toolchain.toml の自動読み取りを公式にサポートしているため、fork が不要になります
- `actions-rs/cargo` → 素の `run:` ステップ
  - 「GitHub の UI にエラー/警告を表示してくれる」という利用理由は、setup-rust-toolchain が登録する problem matcher がそのまま引き継ぎます
- timed-stats-server での置き換え時の知見を反映し、`components: rustfmt, clippy` の明示(デフォルトは minimal プロファイル)と、warning をエラー化してしまう `RUSTFLAGS=-D warnings` 注入の無効化を最初から入れています

## 補足

このリポジトリも buf の community remote plugins を使っており、未認証の BSR リモートプラグイン実行のレート制限(10 req/h/IP)リスクがあります(詳細: GiganticMinecraft/seichi-game-data-server#337)。ローカルプラグイン化は Dockerfile の変更が #198 と競合するため、#198 マージ後に別 PR で提案予定です。

## 動作確認

- actionlint 1.7.12 をローカルで実行し指摘ゼロ
- ワークフローの動作は本 PR の CI で確認できます(Rust ジョブは rust-toolchain.toml の 1.97.1 を使用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
