### PR TITLE
ci: migration イメージのビルド入力を固定し二重実行の回帰テストを追加する

### DIFF
--- a/.github/workflows/build-and-release-application.yaml
+++ b/.github/workflows/build-and-release-application.yaml
@@ -61,9 +61,10 @@ jobs:
           - component_name: ingestor
             image_name: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor
             dockerfile: ./server/Dockerfile-ingestor
-          - component_name: database-migration
-            image_name: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration
-            dockerfile: ./server/Dockerfile-database-migration
+          # database-migration は build-and-release-migration.yaml に分離した。
+          # ビルド入力 (migrations SQL / Dockerfile) が変わったときだけビルドする。
+          # 無関係なアプリ変更での migration イメージ再ビルドによる依存の入れ替わりが
+          # 2026-08-02 インシデントの起点だったため (conifers#200)
 
     name: Build server docker image (and publish on master) for ${{ matrix.component_name }}
     needs: [ lint-and-test ]

--- a/.github/workflows/build-and-release-migration.yaml
+++ b/.github/workflows/build-and-release-migration.yaml
@@ -1,0 +1,151 @@
+# database-migration イメージ専用のビルド/リリース workflow。
+#
+# アプリ本体の CI (build-and-release-application.yaml) から分離している理由:
+# 無関係なアプリ変更で migration イメージが再ビルドされ、ビルド時点の
+# APT パッケージ (libmariadb 等) が入れ替わることが 2026-08-02 インシデント
+# (適用済みマイグレーションの誤再実行で ingest 全停止) の起点だったため。
+# ビルド入力が変わったときだけビルド・配備する (conifers#200)。
+#
+# このため migration イメージの sha タグはアプリ (ingestor) と一致しない。
+# seichi_infra 側は各イメージを独立に bump する。
+name: Migration image
+on:
+  push:
+    paths:
+      - 'server/database/migrations/**'
+      - 'server/diesel.toml'
+      - 'server/Dockerfile-database-migration'
+      - '.github/workflows/build-and-release-migration.yaml'
+
+jobs:
+  build-test-release:
+    name: Build migration image, test idempotency (and publish on master)
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: docker-build-database-migration-${{ github.ref }}
+      cancel-in-progress: true
+    services:
+      # 本番相当 (MariaDB 11.8 系)。二重実行の回帰テスト用
+      mariadb:
+        image: mariadb:11.8
+        env:
+          MARIADB_ROOT_PASSWORD: test
+          MARIADB_DATABASE: conifers-test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "healthcheck.sh --connect --innodb_initialized"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 30
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration
+          tags: |
+            type=sha,prefix=sha-,suffix=,format=short
+
+      - name: Build image for testing
+        uses: docker/build-push-action@v7
+        with:
+          context: ./server
+          file: ./server/Dockerfile-database-migration
+          builder: ${{ steps.buildx.outputs.name }}
+          load: true
+          push: false
+          tags: migration-under-test:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # 2026-08-02 インシデントの故障機構 (適用済みマイグレーションを未適用と
+      # 誤判定して再実行する) を配備前に検出する回帰テスト。
+      # 1 回目: 初回マイグレーションが適用されること
+      # 2 回目: no-op であること (再実行しようとしたら fail)
+      # 最後に、適用記録の version が期待形式 (14 桁数字) で読めることを DB 側でも確認
+      - name: 'Regression test: run migration twice against MariaDB 11.8'
+        run: |
+          set -euxo pipefail
+          run_migration() {
+            docker run --rm --network host \
+              -e DB_HOST_AND_PORT=127.0.0.1:3306 \
+              -e DB_USER=root \
+              -e DB_PASSWORD=test \
+              -e DB_DATABASE_NAME=conifers-test \
+              migration-under-test:local
+          }
+          first=$(run_migration 2>&1 | tee /dev/stderr)
+          grep -q 'Running migration' <<<"$first"
+          second=$(run_migration 2>&1 | tee /dev/stderr)
+          if grep -q 'Running migration' <<<"$second"; then
+            echo '::error::2 回目の migration 実行が no-op になっていない (適用済みマイグレーションを再実行しようとした)'
+            exit 1
+          fi
+          docker exec ${{ job.services.mariadb.id }} \
+            mariadb -uroot -ptest conifers-test --batch -N \
+            -e 'SELECT version FROM __diesel_schema_migrations' | grep -Ex '[0-9]{14}'
+
+      # ビルド入力の記録 (依存一覧・SBOM)。事後に「どの libmariadb が入っていたか」を
+      # イメージを起動せずに追跡できるようにする
+      - name: Record dependency inventory
+        run: |
+          {
+            echo '== diesel --version'
+            docker run --rm --entrypoint diesel migration-under-test:local --version
+            echo '== dpkg -l'
+            docker run --rm --entrypoint dpkg migration-under-test:local -l
+          } > migration-image-deps.txt
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: migration-under-test:local
+          format: spdx-json
+          output-file: migration-image-sbom.spdx.json
+          upload-artifact: false
+
+      - name: Upload build info
+        uses: actions/upload-artifact@v7
+        with:
+          name: migration-image-build-info-${{ github.sha }}
+          path: |
+            migration-image-deps.txt
+            migration-image-sbom.spdx.json
+
+      - name: Push (on master)
+        id: docker_push
+        if: github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./server
+          file: ./server/Dockerfile-database-migration
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+
+      - name: Record pushed digest
+        if: github.ref == 'refs/heads/master'
+        run: |
+          {
+            echo '## Pushed migration image'
+            echo '- tags: `${{ steps.meta.outputs.tags }}`'
+            echo '- digest: `${{ steps.docker_push.outputs.digest }}`'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-and-release-migration.yaml
+++ b/.github/workflows/build-and-release-migration.yaml
@@ -143,9 +143,12 @@ jobs:
 
       - name: Record pushed digest
         if: github.ref == 'refs/heads/master'
+        env:
+          PUSHED_TAGS: ${{ steps.meta.outputs.tags }}
+          PUSHED_DIGEST: ${{ steps.docker_push.outputs.digest }}
         run: |
           {
             echo '## Pushed migration image'
-            echo '- tags: `${{ steps.meta.outputs.tags }}`'
-            echo '- digest: `${{ steps.docker_push.outputs.digest }}`'
+            echo "- tags: \`${PUSHED_TAGS}\`"
+            echo "- digest: \`${PUSHED_DIGEST}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/server/Dockerfile-database-migration
+++ b/server/Dockerfile-database-migration
@@ -3,15 +3,21 @@
 # 文字列カラムを空として読むリグレッションがあり、__diesel_schema_migrations を
 # 読めず適用済みマイグレーションを再実行してしまう (diesel-rs/diesel#5102)。
 # trixie の libmariadb (1:11.8.6) では解消していることを検証済み。
-# base を bookworm に戻さないこと
-FROM rust:1.97.1-slim-trixie
+# base を bookworm に戻さないこと。
+# digest ピンはビルド入力の固定のため (更新は Renovate が追従)。
+# なお APT パッケージはビルド時点のリポジトリを参照するため digest だけでは
+# 固定されない。危険な組合せは CI の migration 二重実行テストで検出する
+FROM rust:1.97.1-slim-trixie@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y default-libmysqlclient-dev && \
     rm -rf /var/lib/apt/lists/* && \
     cargo install diesel_cli --version 2.3.11 --locked --no-default-features --features mysql
 
-COPY --link . .
+# イメージ内容を宣言済みのビルド入力の純関数にするため、実行に必要な
+# ファイルだけを COPY する (COPY . . だと無関係なソース変更でも内容が変わる)
+COPY --link diesel.toml ./
+COPY --link database/migrations ./database/migrations
 
 # DB の接続情報を含んだ環境変数
 ENV DB_HOST_AND_PORT=""

--- a/server/Dockerfile-database-migration
+++ b/server/Dockerfile-database-migration
@@ -19,10 +19,9 @@ RUN apt-get update && \
 COPY --link diesel.toml ./
 COPY --link database/migrations ./database/migrations
 
-# DB の接続情報を含んだ環境変数
-ENV DB_HOST_AND_PORT=""
-ENV DB_USER=""
-ENV DB_PASSWORD=""
-ENV DB_DATABASE_NAME=""
+# DB の接続情報は実行時に環境変数で渡す (すべて必須):
+#   DB_HOST_AND_PORT / DB_USER / DB_PASSWORD / DB_DATABASE_NAME
+# ENV では宣言しない (secret 名の ENV 宣言は BuildKit の
+# SecretsUsedInArgOrEnv 警告対象。値は Kubernetes の Secret から注入される)
 
 ENTRYPOINT ["bash", "-c", "diesel migration run --database-url=mysql://$DB_USER:$DB_PASSWORD@$DB_HOST_AND_PORT/$DB_DATABASE_NAME"]


### PR DESCRIPTION
Closes #200(2026-08-02 インシデントの恒久対策 #2。ポストモーテム: GiganticMinecraft/seichi_infra#5691)

## 変更内容

### 1. ビルド入力の固定(`Dockerfile-database-migration`)

- base を `rust:1.97.1-slim-trixie@sha256:5c6f46...` に **digest 固定**(更新は Renovate の dockerfile manager が追従)
- `COPY . .` をやめ、実行に必要な `diesel.toml` と `database/migrations` だけを COPY。イメージ内容が宣言済みビルド入力の純関数になる
- 注記コメント: APT パッケージは digest では固定されない(その残余リスクは下記回帰テストで検出する設計)

### 2. migration ビルドの分離とパス限定(新規 `build-and-release-migration.yaml`)

- migration イメージのビルド/配備を専用 workflow に分離し、`on.push.paths` で **ビルド入力(migrations SQL / diesel.toml / Dockerfile / workflow 自身)の変更時のみ**実行
- 既存 CI の matrix から database-migration を除去
- **これに伴い migration イメージの sha タグは ingestor と一致しなくなります**。seichi_infra 側は各イメージを独立に bump する運用になります(現行の digest ピン参照はそのまま有効)

### 3. 二重実行の回帰テスト(push 前のゲート)

本番相当の **MariaDB 11.8** を service container で起動し:

1. 1 回目の実行で初回マイグレーションが適用されること
2. **2 回目が no-op であること**(適用済みを再実行しようとしたら fail)— 今回のインシデントの故障機構を直接検出
3. 適用記録の `version` が期待形式(14 桁数字)で読めることを DB 側からも確認 — 空文字列化の変種も検出

### 4. ビルド情報の保存

- 依存一覧(`dpkg -l` / `diesel --version`)と SBOM(syft, spdx-json)を workflow artifact に保存
- master push 時は pushed digest を job summary に記録

## 検証

ローカル(apple container + MariaDB 11.8)で同一手順を実施済み: digest 固定 + COPY 絞り込み後のイメージで 1 回目適用(全 17 テーブル作成)・2 回目 no-op(exit 0, "Running migration" 出力なし)・記録 `20230524025310`(14 桁)を確認。

## 補足

- #199(actions-rs 置き換え)と同じ workflow ファイルを触りますが、別セクション(matrix 部)なので競合しても解消は軽微です
- 純 Rust 化(#201)が入った後も、この workflow のテストと入力固定はそのまま有効です

🤖 Generated with [Claude Code](https://claude.com/claude-code)