### PR TITLE
fix: buf の protoc プラグインをローカル実行に移行し namely/protoc を置き換える

### DIFF
--- a/.github/workflows/build-and-release-application.yaml
+++ b/.github/workflows/build-and-release-application.yaml
@@ -32,6 +32,17 @@ jobs:
 
       # buf CLIがビルドに必要
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          # Dockerfile の bufbuild/buf イメージとバージョンを揃えること
+          version: "1.72.0"
+
+      # pbjson-types などのビルドに protoc が必要
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends protobuf-compiler
+
+      # buf generate (build.rs) が使う protoc プラグイン。バージョンはスクリプト内で固定されている
+      - name: Install protoc plugins for buf generate
+        run: ./server/install-buf-plugins.sh
 
       - name: Cargo fmt
         run: cargo fmt --manifest-path server/Cargo.toml --all -- --check

--- a/server/Dockerfile-ingestor
+++ b/server/Dockerfile-ingestor
@@ -8,16 +8,18 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM bufbuild/buf:1.72.0 as buf
 
-FROM namely/protoc:1.42_2 as protoc
-
 FROM chef AS build-env
-COPY --from=planner --link /app/recipe.json recipe.json
 COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/
-COPY --from=protoc --link /usr/local/bin/protoc /usr/local/bin/
 
-# We need these because cargo chef cook will require protoc to build some modules
-ARG PROTOC_NO_VENDOR=true
-ARG PROTOC=/usr/local/bin/protoc
+# We need protoc because cargo chef cook will require it to build some modules (e.g. pbjson-types)
+RUN apt-get update && apt-get install -y --no-install-recommends protobuf-compiler && rm -rf /var/lib/apt/lists/*
+
+# protoc plugins used by `buf generate` (see infra/upstream_repository_impl/buf.gen.yaml);
+# versions are pinned in install-buf-plugins.sh
+COPY --link install-buf-plugins.sh ./
+RUN ./install-buf-plugins.sh
+
+COPY --from=planner --link /app/recipe.json recipe.json
 
 # Build dependencies - this is the caching Docker layer!
 RUN --mount=type=cache,target=/ingestor/server cargo chef cook --release --recipe-path recipe.json

--- a/server/Dockerfile-ingestor
+++ b/server/Dockerfile-ingestor
@@ -6,7 +6,7 @@ FROM chef AS planner
 COPY --link . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM bufbuild/buf:1.72.0 as buf
+FROM bufbuild/buf:1.72.0 AS buf
 
 FROM chef AS build-env
 COPY --from=buf --link /usr/local/bin/buf /usr/local/bin/

--- a/server/infra/upstream_repository_impl/buf.gen.yaml
+++ b/server/infra/upstream_repository_impl/buf.gen.yaml
@@ -1,8 +1,12 @@
-version: v1
+version: v2
+# 各プラグインは crates.io の protoc-gen-prost / protoc-gen-tonic / protoc-gen-prost-crate を
+# ローカルにインストールして使う (BSR のリモートプラグイン実行は未認証だと 10 req/h/IP の
+# レート制限があり、egress IP を共有する GitHub ホストランナーでは不安定になるため)。
+# インストールは server/install-buf-plugins.sh で行う (バージョンはそこで固定)。
 managed:
   enabled: true
 plugins:
-  - plugin: buf.build/community/neoeinstein-prost:v0.5.0
+  - local: protoc-gen-prost
     out: src/gen
     opt:
       # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost#options
@@ -10,13 +14,13 @@ plugins:
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
       - file_descriptor_set
-  - plugin: buf.build/community/neoeinstein-tonic:v0.5.0
+  - local: protoc-gen-tonic
     out: src/gen
     opt:
       # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-tonic
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
-  - plugin: buf.build/community/neoeinstein-prost-crate:v0.5.0
+  - local: protoc-gen-prost-crate
     out: src/gen
     # https://github.com/neoeinstein/protoc-gen-prost/tree/main/protoc-gen-prost-crate
     opt:

--- a/server/install-buf-plugins.sh
+++ b/server/install-buf-plugins.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# buf generate (build.rs) が使う protoc プラグインを固定バージョンでインストールする。
+# CI・Dockerfile・開発環境で同じ生成結果になるよう、バージョン変更は必ずこのスクリプトだけで行うこと。
+# (バージョンは Cargo.toml の prost / tonic の世代と互換である必要がある)
+set -eu
+
+exec cargo install --locked \
+  protoc-gen-prost@0.5.0 \
+  protoc-gen-tonic@0.5.0 \
+  protoc-gen-prost-crate@0.5.0


### PR DESCRIPTION
## 背景

#199 の補足に書いたとおり、このリポジトリの buf.gen.yaml は BSR の community remote plugins を使っており、[未認証のリモートプラグイン実行は 10 リクエスト/時/IP のレート制限](https://buf.build/docs/bsr/rate-limits/)の影響を受けます(egress IP を共有する GitHub ホストランナーでは 429 のリスク)。#198 がマージされ Dockerfile の競合がなくなったため、他リポジトリと同じ構成に揃えます。

## 変更内容

seichi-timed-stats-server#164 / seichi-game-data-server#337 / seichi-game-data-publisher#202 と同じ構成です。

- **buf.gen.yaml を v2 形式 + ローカルプラグイン実行に移行**(`managed: enabled: true` は v2 でもそのまま有効なことを `buf config migrate` で確認済み)。リモートプラグインと同じバイナリである crates.io の `protoc-gen-prost@0.5.0` / `protoc-gen-tonic@0.5.0` / `protoc-gen-prost-crate@0.5.0` を使うため生成コードは同一です
- **`server/install-buf-plugins.sh`** にプラグインバージョンを一元化(`--locked` 付き)。CI・Dockerfile・開発環境すべてこのスクリプトを使います
- **amd64 専用の `namely/protoc:1.42_2` を廃止**し、apt の `protobuf-compiler` に置換
- CI の buf-setup-action に `version: "1.72.0"` を明示し Dockerfile の buf イメージと一致させる

なお Dockerfile-ingestor の最終ステージには `x86_64-linux-gnu` 決め打ちの libz コピーが残っているため、イメージ全体の arm64 対応はこの PR のスコープ外です(ビルドステージまでは arm64 でも動くようになります)。Dockerfile-database-migration は buf を使わないため変更ありません。

## 動作確認

すべて手元 (macOS / Apple Silicon) で確認済みです。

- `buf generate buf.build/gigantic-minecraft/seichi-game-data` が新設定 + ローカルプラグインで成功
- `cargo fmt --check` / `cargo build` / `cargo clippy` (エラー 0) / `cargo test`: Rust 1.97.1 で通過
- `container build --target build-env -f Dockerfile-ingestor`: ビルドステージ完走(コンテナ内での protoc / プラグイン導入 → buf generate → リリースビルドまで)
- actionlint: 指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
