### PR TITLE
chore: 開発用 DB イメージを本番と同じ MariaDB 11.8 (LTS) に固定する

### DIFF
--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mysql:9.7.1
+    image: mariadb:11.8
     environment:
       - TZ=Asia/Tokyo
       - MYSQL_ROOT_PASSWORD=password

--- a/server/dev-db.docker-compose.yaml
+++ b/server/dev-db.docker-compose.yaml
@@ -4,8 +4,8 @@ version: "3.9"
 services:
   db:
     # プロダクションが利用しているバージョンと合わせるべき
-    # https://github.com/GiganticMinecraft/seichi_infra/blob/8b229bb67976b1698fd20ca5ff16ba1f6f91fecb/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml#LL19C11-L19C18
-    image: mariadb:10.11.3
+    # https://github.com/GiganticMinecraft/seichi_infra/blob/e9f270c3ce45d7479f5fda2f4e1d7c1be0bf149f/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml#L14
+    image: mariadb:11.8
     environment:
       MYSQL_USER: mariadb
       MYSQL_PASSWORD: password


### PR DESCRIPTION
## 概要

開発用 DB のイメージがバラバラかつ古くなっていたので、本番 ([seichi_infra の mariadb.yaml](https://github.com/GiganticMinecraft/seichi_infra/blob/e9f270c3ce45d7479f5fda2f4e1d7c1be0bf149f/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml#L14)) と同じ MariaDB 11.8 (LTS) に揃えます。

- `docker-compose-db.yml`: `mysql:9.7.1` (Oracle MySQL) → `mariadb:11.8`。本番は MariaDB なので別物の DB でテストしている状態でした
- `server/dev-db.docker-compose.yaml`: `mariadb:10.11.3` → `mariadb:11.8`。コメントの本番マニフェストへのリンクも現行のものに更新

CI (`build-and-release-migration.yaml`) は既に `mariadb:11.8` を使用しており、これで全て統一されます。

## 補足

MariaDB 11.8 は `innodb_snapshot_isolation` がデフォルト ON なので、10.11 との差異としてこの挙動が開発環境でも再現されるようになります（本番は既にこの挙動）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)